### PR TITLE
Resolved warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+git_source(:github) {|repo| "https://github.com/#{repo}.git" }
+
 ruby "2.5.1"
 
 # Distribute your app as a gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/padrino/padrino-framework.git
+  remote: https://github.com/padrino/padrino-framework.git
   revision: c27107001bb66c9144917dd146dac1ab7bcf7b24
   ref: c271070
   branch: master


### PR DESCRIPTION
The git source `git://github.com/padrino/padrino-framework.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.