### PR TITLE
Rollback to `circleci/postgres`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
       - image: cimg/ruby:3.0.2
         environment:
           RACK_ENV: test
-      - image: cimg/postgres:9.6
+      - image: circleci/postgres:9.4-alpine-ram
         environment:
           POSTGRES_USER: ubuntu
           POSTGRES_DB: circle_test


### PR DESCRIPTION
`cimg/postgres` is broken...

```
server started
psql: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
LOG:  received SIGHUP, reloading configuration files
LOG:  parameter "listen_addresses" cannot be changed without restarting the server
LOG:  configuration file "/var/lib/postgresql/data/postgresql.conf" contains errors; unaffected changes were applied

Exited with code 2
```

https://app.circleci.com/pipelines/github/sue445/ccc_privacy_crawler/1294/workflows/706b5e3e-a7a4-4de6-a0c1-39a05a7ff350/jobs/4439

ref. https://github.com/CircleCI-Public/cimg-postgres/issues/21